### PR TITLE
Warnings on fclose

### DIFF
--- a/dir-generator.php
+++ b/dir-generator.php
@@ -247,7 +247,7 @@ if($handle = @opendir($path)) {
 			);
 		}
 	}
-	fclose($handle);
+	closedir($handle);
 }
 
 


### PR DESCRIPTION
We are working on directories, so we should close directory instead of file-handle.. if not, it generates Warn-messages.
